### PR TITLE
Add -mcmodel=kernel to list of no-pie exceptions

### DIFF
--- a/cc-wrapper.sh
+++ b/cc-wrapper.sh
@@ -17,7 +17,7 @@ optimizing=0
 
 for opt; do
   case "$opt" in
-    -fno-PIC|-fno-pic|-fno-PIE|-fno-pie|-nopie|-static|--static|-shared|--shared|-D__KERNEL__|-nostdlib|-nostartfiles)
+    -fno-PIC|-fno-pic|-fno-PIE|-fno-pie|-nopie|-static|--static|-shared|--shared|-D__KERNEL__|-nostdlib|-nostartfiles|-mcmodel=kernel)
       force_fPIE=0
       force_pie=0
       ;;


### PR DESCRIPTION
Not sure why this only broke now, but without this change I get:

```
scripts/mod/empty.c:1:0: error: code model kernel does not support PIC mode
```

When compiling linux 3.19.1
